### PR TITLE
Fix critical SEO & social sharing growth blockers 🚀

### DIFF
--- a/PizzaPyWebApp/static/robots.txt
+++ b/PizzaPyWebApp/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.pizzapy.ph/sitemap.xml

--- a/PizzaPyWebApp/static/sitemap.xml
+++ b/PizzaPyWebApp/static/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.pizzapy.ph/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.pizzapy.ph/about_us/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.pizzapy.ph/events/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>

--- a/PizzaPyWebApp/templates/base.html
+++ b/PizzaPyWebApp/templates/base.html
@@ -6,29 +6,36 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Favicon -->
-  <link rel="icon" href="../static/images/favicon_io/favicon-16x16.png" sizes="16x16" type="image/png">
-  <link rel="icon" href="../static/images/favicon_io/favicon-32x32.png" sizes="32x32" type="image/png">
-  <link rel="icon" href="../static/images/favicon_io/android-chrome-192x192.png" sizes="192x192" type="image/png">
-  <link rel="icon" href="../static/images/favicon_io/android-chrome-512x512.png" sizes="512x512" type="image/png">
-  <link rel="apple-touch-icon" href="../static/images/favicon_io/apple-touch-icon.png">
+  <link rel="icon" href="/static/images/favicon_io/favicon-16x16.png" sizes="16x16" type="image/png">
+  <link rel="icon" href="/static/images/favicon_io/favicon-32x32.png" sizes="32x32" type="image/png">
+  <link rel="icon" href="/static/images/favicon_io/android-chrome-192x192.png" sizes="192x192" type="image/png">
+  <link rel="icon" href="/static/images/favicon_io/android-chrome-512x512.png" sizes="512x512" type="image/png">
+  <link rel="apple-touch-icon" href="/static/images/favicon_io/apple-touch-icon.png">
+
+  <!-- SEO: Meta description for search results -->
+  {% block meta_description %}
+  <meta name="description" content="PizzaPy Cebu Python Users Group — a volunteer-run community of Python developers, testers, and tech enthusiasts in Cebu, Philippines. Join us for meetups, workshops, and talks.">
+  {% endblock %}
 
   <!-- Open Graph Meta Tags (used by LinkedIn, Facebook, etc.) -->
   <meta name="og:card" content="summary_large_image">
-  <meta property="og:title" content="PIZZAPY CEBU PYTHON USERS GROUP">
-  <meta property="og:description" content="A Python Users Group based in Cebu, Philippines">
-  <meta property="og:image" content="../static/images/group.png">
-  <meta property="og:url" content="http://localhost:3000">
+  <meta property="og:title" content="{% block og_title %}PizzaPy Cebu — Python Users Group{% endblock %}">
+  <meta property="og:description" content="{% block og_description %}A volunteer-run community of Python developers, testers, and tech enthusiasts in Cebu, Philippines. Join us for meetups, workshops, and talks.{% endblock %}">
+  <meta property="og:image" content="https://www.pizzapy.ph/static/images/group.png">
+  <meta property="og:url" content="https://www.pizzapy.ph">
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PizzaPy Cebu">
+  <meta property="og:locale" content="en_PH">
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="PIZZAPY CEBU PYTHON USERS GROUP">
-  <meta name="twitter:description" content="A Python Users Group based in Cebu, Philippines">
-  <meta name="twitter:image" content="../static/images/group.png">
-  <meta property="twitter:url" content="http://localhost:3000">
+  <meta name="twitter:title" content="PizzaPy Cebu — Python Users Group">
+  <meta name="twitter:description" content="A volunteer-run community of Python developers, testers, and tech enthusiasts in Cebu, Philippines.">
+  <meta name="twitter:image" content="https://www.pizzapy.ph/static/images/group.png">
+  <meta property="twitter:url" content="https://www.pizzapy.ph">
   <meta property="twitter:type" content="website">
 
-  <title>{% block title %}{% endblock %}</title>
+  <title>{% block title %}PizzaPy Cebu — Python Users Group{% endblock %}</title>
   {% load static %}
   <link rel="stylesheet" href="{% static 'css/output.css' %}" />
   <script src="https://unpkg.com/htmx.org@1.9.2"


### PR DESCRIPTION
## Critical Growth Blockers Fixed

### 🔴 CRITICAL — All social shares were dead links
Every `og:url` and `twitter:url` meta tag pointed to `http://localhost:3000` instead of `https://www.pizzapy.ph`. **Every single time someone shared pizzapy.ph on Facebook, Twitter, LinkedIn, or WhatsApp, the link preview pointed to a dead localhost URL.** This completely killed social traffic growth.

### 🟡 HIGH — No meta description
Google was auto-generating search result snippets. Added a compelling meta description for better click-through rates.

### 🟡 MEDIUM — No robots.txt or sitemap.xml
Search engines had zero crawling directives. Added both for proper indexing of `/`, `/about_us/`, and `/events/`.

### 🟡 MEDIUM — Favicon relative paths broken on sub-pages
Changed `../static/` to `/static/` so favicons load correctly on all pages.

### ✅ Bonus improvements
- Added `og:site_name` and `og:locale` for better Facebook sharing
- Added Django template blocks for per-page title/description overrides
- Default title fallback for pages without custom titles

---
*PR submitted by [Hans Koch](https://github.com/hansakoch) — met at the Cebu OpenClaw meetup 🦞*